### PR TITLE
Improve login error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The CLI provides a list of actions, that you can use:
 
  | Actions | Description |
  |---------|-------------|
- | login   | Login to the Epic Services. This will require an authentication code, which you must get by logging into your account [in your browser](https://www.epicgames.com/id/api/redirect?clientId=34a02cf8f4414e29b15921876da36f9a&responseType=code). The login will be stored in your keyring, so you don't need to enter in every time. |
+| login   | Login to the Epic Services. This will require an authentication code, which you must get by logging into your account [in your browser](https://www.epicgames.com/id/api/redirect?clientId=34a02cf8f4414e29b15921876da36f9a&responseType=code). The login will be stored in your keyring, so you don't need to enter in every time. If you receive a `corrective_action_required` error when logging in, open the Epic Games Store in your browser and accept the EULA for your account. |
  | list    | List the assets and their available Versions. |
  | details | Get the full details, including which Versions work with which Engine Version, for a specific detail. |
  | download | Download a given Asset + Version into a desired Directory on your system. |

--- a/ue_asset_cli/login.py
+++ b/ue_asset_cli/login.py
@@ -48,14 +48,30 @@ def _login_with_authentication_code(session: Session, authentication_code: str) 
     }
 
     user_data = session.post(TOKEN_URL, data, auth=(CLIENT_ID, CLIENT_SECRET))
-    user_data.raise_for_status()
 
     if user_data.status_code == 200:
         log.info("Successful login with authentication code")
         return user_data.json()
-    else:
-        log.error("Could not login with Authentication Code")
-        return None
+
+    # Check if the response indicates that the user has not yet accepted
+    # the Epic Games EULA.  Epic recently changed the OAuth flow to return a
+    # 4xx status code with a JSON body that contains the corrective action.
+    try:
+        error_data = user_data.json()
+        if (
+            error_data.get("errorCode") == "errors.com.epicgames.oauth.corrective_action_required"
+            and error_data.get("metadata", {}).get("correctiveAction") == "EULA_ACCEPTANCE"
+        ):
+            log.error(
+                "Login failed: Epic Games EULA must be accepted in your browser before logging in."
+            )
+            log.debug(f"Continuation token: {error_data.get('metadata', {}).get('continuation')}")
+    except Exception:
+        # Ignore errors when parsing the json message
+        pass
+
+    log.error("Could not login with Authentication Code")
+    return None
 
 
 def _verify_authentication_token(session: Session, token: str) -> dict | None:


### PR DESCRIPTION
## Summary
- display explicit message if login fails due to missing EULA acceptance
- document corrective_action_required in README

## Testing
- `pip install -e .`
- `python -m compileall -q ue_asset_cli`


------
https://chatgpt.com/codex/tasks/task_e_684afb8d4f90832685b9946a1d95fcfe